### PR TITLE
Patch: Fix client docker build

### DIFF
--- a/client/.docker/entrypoint.sh
+++ b/client/.docker/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "Starting client server on PORT=3000 ..."
+serve -s ./build/ -l 3000

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -4,9 +4,10 @@ WORKDIR /app
 COPY package.json yarn.lock ./
 RUN npm install
 RUN npm install -g serve
+RUN apk add --update bash git openssl
 
 COPY . .
-RUN npm build
+RUN npm run build
 
 EXPOSE 3000
-ENTRYPOINT [ "serve", "-s", "build/", "-l", "3000" ]
+ENTRYPOINT [ "./.docker/entrypoint.sh" ]


### PR DESCRIPTION
Fixed some issues with docker images including `npm build` -> `npm run build` on client which was preventing a proper build to be generated for production.